### PR TITLE
Fix mapping and disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ with a strong preference for staying in terminal windows).
 Starts out enabled when sourced, assuming you always want to see the scrollbar.
 If you'd like to default to starting unsourced, add this to your `.vimrc:`
 
-    " Prevents loading by telling the plugin it's already loaded. You'll have
-    " to :call ToggleScrollbar()<CR> if you want to load it manually.
-    let g:loaded_scrollbar=1
+    " Prevents scrollbar setup. `:call ToggleScrollbar()<CR>` if you want to enable manually
+    let g:scrollbar_active = 0
 
 Default settings. These can be overridden by putting these in your `.vimrc`:
 

--- a/plugin/scrollbar.vim
+++ b/plugin/scrollbar.vim
@@ -59,6 +59,9 @@ call <sid>SetScrollbarActiveIfUninitialized()
 " Function to toggle the scrollbar.
 function! ToggleScrollbar()
     call <sid>SetScrollbarActiveIfUninitialized()
+
+    let g:scrollbar_active = !g:scrollbar_active
+
     if b:scrollbar_active
         " Toggle to inactive mode.
         let b:scrollbar_active=0

--- a/plugin/scrollbar.vim
+++ b/plugin/scrollbar.vim
@@ -51,7 +51,7 @@ function! <sid>SetScrollbarActiveIfUninitialized()
         let b:scrollbar_active=g:scrollbar_active
     endif
     if !exists('g:scrollbar_binding_active')
-        let g:scrollbar_binding_active=1
+        let g:scrollbar_binding_active=0
     endif
 endfunction
 call <sid>SetScrollbarActiveIfUninitialized()

--- a/plugin/scrollbar.vim
+++ b/plugin/scrollbar.vim
@@ -113,6 +113,7 @@ function! SetupScrollbarBindings()
     :nnoremap <silent> j j:call RefreshScrollbar()<CR>
     :nnoremap <silent> k k:call RefreshScrollbar()<CR>
 
+    :nnoremap <silent> N N:call RefreshScrollbar()<CR>
     :nnoremap <silent> n n:call RefreshScrollbar()<CR>
 
     :nnoremap <silent> <UP> <UP>:call RefreshScrollbar()<CR>


### PR DESCRIPTION
Fixes #13: `g:scrollbar_binding_active` was defaulted to 1 so setup was being skipped
Fixes #11: `let g:loaded_scrollbar=1` prevents sourcing the rest of the script, so ToggleScrollbar() wouldn't be defined
Adds `N` map